### PR TITLE
grpc-bom dependency doesn't properly generate in pom.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,11 +92,11 @@ spotless {
 dependencies {
   api "org.wiremock:wiremock:$versions.wiremock"
 
-  api "io.grpc:grpc-bom:$versions.grpc"
-  api "io.grpc:grpc-protobuf:$versions.grpc"
-  api "io.grpc:grpc-stub:$versions.grpc"
+  api platform("io.grpc:grpc-bom:$versions.grpc")
+  api "io.grpc:grpc-protobuf"
+  api "io.grpc:grpc-stub"
 
-  implementation "io.grpc:grpc-servlet-jakarta:$versions.grpc"
+  implementation "io.grpc:grpc-servlet-jakarta"
   implementation "com.google.protobuf:protobuf-java-util:$versions.protobuf"
 
   implementation 'javax.annotation:javax.annotation-api:1.3.2'
@@ -108,7 +108,7 @@ dependencies {
   testImplementation "org.hamcrest:hamcrest-library:2.2"
   testImplementation 'org.awaitility:awaitility:4.2.0'
 
-  testImplementation "io.grpc:grpc-okhttp:$versions.grpc"
+  testImplementation "io.grpc:grpc-okhttp"
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
This was discussed in https://wiremock-community.slack.com/archives/C03NAEH5LVA/p1698103015215289

As it stands today, the `grpc-bom` artifact in the resulting `pom.xml` is declared as a jar dependency in the `<dependencies>` section, rather than a pom import dependency within the `<dependencyManagement>` section of `pom.xml`.

This causes clients using Maven to fail when using this library:

If adding this to `pom.xml`:

```xml
<dependency>
  <groupId>org.wiremock</groupId>
  <artifactId>wiremock-grpc-extension</artifactId>
  <version>0.2.0</version>
  <scope>test</scope>
</dependency>
```

it results in:

```log
╰─ ./mvnw clean package -DskipTests
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< io.quarkus.sample.super-heroes:rest-fights >-------------
[INFO] Building Quarkus Sample :: Super-Heroes :: Fights Microservice 1.0
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo1.maven.org/maven2/io/grpc/grpc-bom/1.58.0/grpc-bom-1.58.0.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.454 s
[INFO] Finished at: 2023-10-23T19:10:07-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project rest-fights: Could not resolve dependencies for project io.quarkus.sample.super-heroes:rest-fights:jar:1.0: The following artifacts could not be resolved: io.grpc:grpc-bom:jar:1.58.0 (absent): Could not find artifact io.grpc:grpc-bom:jar:1.58.0 in central (https://repo1.maven.org/maven2/) -> [Help 1]
```

After this change, the resulting `pom.xml` looks like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <!-- This module was also published with a richer model, Gradle metadata,  -->
  <!-- which should be used instead. Do not delete the following line which  -->
  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
  <!-- that they should prefer consuming it instead. -->
  <!-- do_not_remove: published-with-gradle-metadata -->
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.wiremock</groupId>
  <artifactId>wiremock-grpc-extension</artifactId>
  <version>0.1.0</version>
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>io.grpc</groupId>
        <artifactId>grpc-bom</artifactId>
        <version>1.58.0</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>org.wiremock</groupId>
      <artifactId>wiremock</artifactId>
      <version>3.2.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-protobuf</artifactId>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-stub</artifactId>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.grpc</groupId>
      <artifactId>grpc-servlet-jakarta</artifactId>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>com.google.protobuf</groupId>
      <artifactId>protobuf-java-util</artifactId>
      <version>3.24.0</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>javax.annotation</groupId>
      <artifactId>javax.annotation-api</artifactId>
      <version>1.3.2</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
  <description>Mock gRPC services with WireMock</description>
  <name>WireMock Extension for gRPC</name>
  <url>https://wiremock.org/</url>
  <scm>
    <connection>https://github.com/wiremock/wiremock-grpc-extension.git</connection>
    <developerConnection>https://github.com/wiremock/wiremock-grpc-extension.git</developerConnection>
    <url>https://github.com/wiremock/wiremock-grpc-extension</url>
  </scm>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/license/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>tomakehurst</id>
      <name>Tom Akehurst</name>
    </developer>
  </developers>
</project>
```

`./gradlew clean check` still is successful and a maven client is able to pull the dependency properly after this change.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [X ] The PR request is well described and justified, including the body and the references
- [X ] The PR title represents the desired changelog entry
- [X ] The repository's code style is followed (see the contributing guide)
- [ X] Test coverage that demonstrates that the change works as expected
- [ ]X For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
