### PR TITLE
Add verification to WireMockGrpcService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,8 @@ test {
     events "PASSED", "FAILED", "SKIPPED"
     exceptionFormat "full"
   }
+
+  useJUnitPlatform()
 }
 
 project.tasks.signMainPublication.dependsOn jar

--- a/src/main/java/org/wiremock/grpc/dsl/GrpcStubMappingBuilder.java
+++ b/src/main/java/org/wiremock/grpc/dsl/GrpcStubMappingBuilder.java
@@ -17,6 +17,7 @@ package org.wiremock.grpc.dsl;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import java.util.ArrayList;
@@ -51,9 +52,21 @@ public class GrpcStubMappingBuilder {
   }
 
   public StubMapping build(String serviceName) {
-    final String path = "/" + serviceName + "/" + method;
+    final String path = createPath(serviceName);
     final MappingBuilder mappingBuilder = WireMock.post(WireMock.urlPathEqualTo(path));
     requestMessageJsonPatterns.forEach(mappingBuilder::withRequestBody);
     return mappingBuilder.willReturn(responseBuilder.build()).build();
+  }
+
+  public RequestPatternBuilder buildRequestMatcher(String serviceName) {
+    final String path = createPath(serviceName);
+    final RequestPatternBuilder requestPatternBuilder =
+        WireMock.postRequestedFor(WireMock.urlPathEqualTo(path));
+    requestMessageJsonPatterns.forEach(requestPatternBuilder::withRequestBody);
+    return requestPatternBuilder;
+  }
+
+  private String createPath(String serviceName) {
+    return "/" + serviceName + "/" + method;
   }
 }

--- a/src/main/java/org/wiremock/grpc/dsl/WireMockGrpcService.java
+++ b/src/main/java/org/wiremock/grpc/dsl/WireMockGrpcService.java
@@ -15,9 +15,12 @@
  */
 package org.wiremock.grpc.dsl;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import org.wiremock.annotations.Beta;
+
+import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 @Beta(justification = "Incubating extension: https://github.com/wiremock/wiremock/issues/2383")
 public class WireMockGrpcService {
@@ -34,5 +37,31 @@ public class WireMockGrpcService {
     final StubMapping stubMapping = builder.build(serviceName);
     wireMock.register(stubMapping);
     return stubMapping;
+  }
+
+  public void resetAll() {
+    this.wireMock.resetToDefaultMappings();
+  }
+
+  public void verifyThat(GrpcStubMappingBuilder builder) {
+    final RequestPatternBuilder requestPatternBuilder =
+        builder.buildRequestMatcher(this.serviceName);
+    this.wireMock.verifyThat(requestPatternBuilder);
+  }
+
+  public void verifyThat(CountMatchingStrategy expectedCount, GrpcStubMappingBuilder builder) {
+    final RequestPatternBuilder requestPatternBuilder =
+        builder.buildRequestMatcher(this.serviceName);
+    this.wireMock.verifyThat(expectedCount, requestPatternBuilder);
+  }
+
+  public void verifyThat(int expectedCount, GrpcStubMappingBuilder builder) {
+    final RequestPatternBuilder requestPatternBuilder =
+        builder.buildRequestMatcher(this.serviceName);
+    this.wireMock.verifyThat(expectedCount, requestPatternBuilder);
+  }
+
+  public void verifyNeverCalled(GrpcStubMappingBuilder builder) {
+    verifyThat(0, builder);
   }
 }


### PR DESCRIPTION
This pull requests adds verification to the `WireMockGrpcService` class. Additionally, all the tests in `GrpcAcceptanceTest` have been updated to use the new verifications.

I did find that I had to add `useJUnitPlatform()` to the `test` closure in `build.gradle` in order for the tests to even execute.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
