### PR TITLE
`GrpcResponseDefinitionBuilder.withFixedDelay`  returning `null` instead of `this`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ publishing {
 }
 
 test {
+  useJUnitPlatform()
   testLogging {
     events "PASSED", "FAILED", "SKIPPED"
     exceptionFormat "full"

--- a/src/main/java/org/wiremock/grpc/dsl/GrpcResponseDefinitionBuilder.java
+++ b/src/main/java/org/wiremock/grpc/dsl/GrpcResponseDefinitionBuilder.java
@@ -63,7 +63,7 @@ public class GrpcResponseDefinitionBuilder {
 
   public GrpcResponseDefinitionBuilder withFixedDelay(long milliseconds) {
     this.delay = new FixedDelayDistribution(milliseconds);
-    return null;
+    return this;
   }
 
   public GrpcResponseDefinitionBuilder withRandomDelay(DelayDistribution distribution) {


### PR DESCRIPTION
`GrpcResponseDefinitionBuilder.withFixedDelay` was returning `null` rather than `this`.

This would most likely have been caught if #34 were in place