### PR TITLE
support multiple URLs as to read desc files

### DIFF
--- a/src/main/java/org/wiremock/grpc/GrpcExtensionFactory.java
+++ b/src/main/java/org/wiremock/grpc/GrpcExtensionFactory.java
@@ -18,6 +18,8 @@ package org.wiremock.grpc;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionFactory;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
+
+import java.net.URL;
 import java.util.List;
 import org.wiremock.annotations.Beta;
 import org.wiremock.grpc.internal.GrpcHttpServerFactory;
@@ -25,8 +27,20 @@ import org.wiremock.grpc.internal.GrpcHttpServerFactory;
 @Beta(justification = "Incubating extension: https://github.com/wiremock/wiremock/issues/2383")
 public class GrpcExtensionFactory implements ExtensionFactory {
 
+  private List<URL> urls;
+
+  public GrpcExtensionFactory() {
+  }
+
+  public GrpcExtensionFactory(List<URL> urls) {
+    this.urls = urls;
+  }
+
   @Override
   public List<Extension> create(WireMockServices services) {
+    if(this.urls !=null){
+       return List.of(new GrpcHttpServerFactory(this.urls));
+    }
     return List.of(new GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")));
   }
 }


### PR DESCRIPTION
This allows reading of the desc files from multiple URLs instead of the wiremock grpc subdirectory 

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
