### PR TITLE
Use the configured Notifier to log messages

### DIFF
--- a/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
@@ -18,6 +18,8 @@ package org.wiremock.grpc.internal;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_NAME;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_REASON;
 
+import com.github.tomakehurst.wiremock.common.LocalNotifier;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -32,12 +34,16 @@ import org.wiremock.grpc.dsl.WireMockGrpc;
 public class ClientStreamingServerCallHandler extends BaseCallHandler
     implements ServerCalls.ClientStreamingMethod<DynamicMessage, DynamicMessage> {
 
+  private final Notifier notifier;
+
   public ClientStreamingServerCallHandler(
       StubRequestHandler stubRequestHandler,
       Descriptors.ServiceDescriptor serviceDescriptor,
       Descriptors.MethodDescriptor methodDescriptor,
-      JsonMessageConverter jsonMessageConverter) {
+      JsonMessageConverter jsonMessageConverter,
+      Notifier notifier) {
     super(stubRequestHandler, serviceDescriptor, methodDescriptor, jsonMessageConverter);
+      this.notifier = notifier;
   }
 
   @Override
@@ -64,6 +70,7 @@ public class ClientStreamingServerCallHandler extends BaseCallHandler
                 methodDescriptor.getName(),
                 jsonMessageConverter.toJson(request));
 
+        LocalNotifier.set(notifier);
         stubRequestHandler.handle(
             wireMockRequest,
             (req, resp, attributes) -> {

--- a/src/main/java/org/wiremock/grpc/internal/GrpcFilter.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcFilter.java
@@ -18,6 +18,7 @@ package org.wiremock.grpc.internal;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.github.tomakehurst.wiremock.common.Exceptions;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
@@ -42,13 +43,15 @@ public class GrpcFilter extends HttpFilter {
   private final GrpcServlet grpcServlet;
   private final StubRequestHandler stubRequestHandler;
   private final List<Descriptors.FileDescriptor> fileDescriptors;
+  private final Notifier notifier;
 
   private final JsonMessageConverter jsonMessageConverter;
 
   public GrpcFilter(
-      StubRequestHandler stubRequestHandler, List<Descriptors.FileDescriptor> fileDescriptors) {
+      StubRequestHandler stubRequestHandler, List<Descriptors.FileDescriptor> fileDescriptors, Notifier notifier) {
     this.stubRequestHandler = stubRequestHandler;
     this.fileDescriptors = fileDescriptors;
+    this.notifier = notifier;
 
     final TypeRegistry.Builder typeRegistryBuilder = TypeRegistry.newBuilder();
     fileDescriptors.forEach(
@@ -90,10 +93,10 @@ public class GrpcFilter extends HttpFilter {
     return methodDescriptor.isClientStreaming()
         ? ServerCalls.asyncClientStreamingCall(
             new ClientStreamingServerCallHandler(
-                stubRequestHandler, serviceDescriptor, methodDescriptor, jsonMessageConverter))
+                stubRequestHandler, serviceDescriptor, methodDescriptor, jsonMessageConverter, notifier))
         : ServerCalls.asyncUnaryCall(
             new UnaryServerCallHandler(
-                stubRequestHandler, serviceDescriptor, methodDescriptor, jsonMessageConverter));
+                stubRequestHandler, serviceDescriptor, methodDescriptor, jsonMessageConverter, notifier));
   }
 
   private static MethodDescriptor<DynamicMessage, DynamicMessage> buildMessageDescriptorInstance(

--- a/src/main/java/org/wiremock/grpc/internal/GrpcHttpServerFactory.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcHttpServerFactory.java
@@ -79,7 +79,7 @@ public class GrpcHttpServerFactory implements HttpServerFactory {
       protected void decorateMockServiceContextBeforeConfig(
           ServletContextHandler mockServiceContext) {
 
-        final GrpcFilter grpcFilter = new GrpcFilter(stubRequestHandler, fileDescriptors);
+        final GrpcFilter grpcFilter = new GrpcFilter(stubRequestHandler, fileDescriptors, options.notifier());
         final FilterHolder filterHolder = new FilterHolder(grpcFilter);
         mockServiceContext.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
       }

--- a/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
@@ -19,6 +19,8 @@ import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_NA
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_REASON;
 import static org.wiremock.grpc.internal.Delays.delayIfRequired;
 
+import com.github.tomakehurst.wiremock.common.LocalNotifier;
+import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -32,12 +34,16 @@ import org.wiremock.grpc.dsl.WireMockGrpc;
 public class UnaryServerCallHandler extends BaseCallHandler
     implements ServerCalls.UnaryMethod<DynamicMessage, DynamicMessage> {
 
+  private final Notifier notifier;
+
   public UnaryServerCallHandler(
       StubRequestHandler stubRequestHandler,
       Descriptors.ServiceDescriptor serviceDescriptor,
       Descriptors.MethodDescriptor methodDescriptor,
-      JsonMessageConverter jsonMessageConverter) {
+      JsonMessageConverter jsonMessageConverter,
+      Notifier notifier) {
     super(stubRequestHandler, serviceDescriptor, methodDescriptor, jsonMessageConverter);
+    this.notifier = notifier;
   }
 
   @Override
@@ -53,6 +59,7 @@ public class UnaryServerCallHandler extends BaseCallHandler
             methodDescriptor.getName(),
             jsonMessageConverter.toJson(request));
 
+    LocalNotifier.set(notifier);
     stubRequestHandler.handle(
         wireMockRequest,
         (req, resp, attributes) -> {

--- a/src/test/java/org/wiremock/grpc/TestNotifier.java
+++ b/src/test/java/org/wiremock/grpc/TestNotifier.java
@@ -1,0 +1,41 @@
+package org.wiremock.grpc;
+
+import com.github.tomakehurst.wiremock.common.Notifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestNotifier implements Notifier {
+
+    public List<String> infoMessages = new ArrayList<>();
+    public List<String> errorMessages = new ArrayList<>();
+    public List<Throwable> throwables = new ArrayList<>();
+
+    public int numberOfMessages = 0;
+
+    public void clear() {
+        infoMessages.clear();
+        errorMessages.clear();
+        throwables.clear();
+        numberOfMessages = 0;
+    }
+
+    @Override
+    public void info(String message) {
+        infoMessages.add(message);
+        System.out.println(++numberOfMessages + "\t" + message);
+    }
+
+    @Override
+    public void error(String message) {
+        errorMessages.add(message);
+        System.err.println(++numberOfMessages + "\t" + message);
+    }
+
+    @Override
+    public void error(String message, Throwable t) {
+        errorMessages.add(message);
+        throwables.add(t);
+        System.err.println(++numberOfMessages + "\t" + message);
+    }
+}


### PR DESCRIPTION
The GrpcHttpServerFactory passes the configured notifier into the GrpcFilter.
The GrpcFilter stores that as a new field, and then passes it on to the handlers that it builds.
The handlers also store the notifier as a new field, and then set the it in the LocalNotifier thread-local before invoking `stubRequestHandler.handle`.

## References

[Issue#38](https://github.com/wiremock/wiremock-grpc-extension/issues/38) _verbose console output_

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ x] The PR request is well described and justified, including the body and the references
- [x ] The PR title represents the desired changelog entry
- [x ] The repository's code style is followed (see the contributing guide)
- [x ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
