### PR TITLE
add some leeway to delay test.

### DIFF
--- a/src/test/java/org/wiremock/grpc/GrpcAcceptanceTest.java
+++ b/src/test/java/org/wiremock/grpc/GrpcAcceptanceTest.java
@@ -284,7 +284,7 @@ public class GrpcAcceptanceTest {
     stopwatch.stop();
 
     assertThat(greeting, is("Delayed hello"));
-    assertThat(stopwatch.elapsed(), greaterThanOrEqualTo(Duration.ofMillis(1000L)));
+    assertThat(stopwatch.elapsed(), greaterThanOrEqualTo(Duration.ofMillis(990L)));
   }
 
   @Test


### PR DESCRIPTION
this test is frequently failing in ci.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
