### PR TITLE
Copy headers to internal WireMock model

### DIFF
--- a/src/main/java/org/wiremock/grpc/internal/GrpcRequest.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcRequest.java
@@ -82,32 +82,32 @@ public class GrpcRequest implements Request {
 
   @Override
   public String getHeader(String key) {
-    return null;
+    return header(key).firstValue();
   }
 
   @Override
   public HttpHeader header(String key) {
-    return HttpHeader.absent(key);
+    return getHeaders().getHeader(key);
   }
 
   @Override
   public ContentTypeHeader contentTypeHeader() {
-    return ContentTypeHeader.absent();
+    return getHeaders().getContentTypeHeader();
   }
 
   @Override
   public HttpHeaders getHeaders() {
-    return HttpHeaders.noHeaders();
+    return HeaderCopyingServerInterceptor.HTTP_HEADERS_CONTEXT_KEY.get();
   }
 
   @Override
   public boolean containsHeader(String key) {
-    return false;
+    return getHeader(key) != null;
   }
 
   @Override
   public Set<String> getAllHeaderKeys() {
-    return emptySet();
+    return getHeaders().keys();
   }
 
   @Override

--- a/src/main/java/org/wiremock/grpc/internal/HeaderCopyingServerInterceptor.java
+++ b/src/main/java/org/wiremock/grpc/internal/HeaderCopyingServerInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import io.grpc.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HeaderCopyingServerInterceptor implements ServerInterceptor {
+
+  public static final Context.Key<HttpHeaders> HTTP_HEADERS_CONTEXT_KEY =
+      Context.key("HTTP_HEADERS_CONTEXT_KEY");
+
+  @Override
+  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    final HttpHeaders httpHeaders = buildHttpHeaders(headers);
+    Context newContext = Context.current().withValue(HTTP_HEADERS_CONTEXT_KEY, httpHeaders);
+    return Contexts.interceptCall(newContext, call, headers, next);
+  }
+
+  private static HttpHeaders buildHttpHeaders(Metadata metadata) {
+    final List<HttpHeader> httpHeaderList =
+        metadata.keys().stream()
+            .map(
+                key ->
+                    new HttpHeader(
+                        key, metadata.get(Metadata.Key.of(key, ASCII_STRING_MARSHALLER))))
+            .collect(Collectors.toList());
+    return new HttpHeaders(httpHeaderList);
+  }
+}

--- a/src/test/java/org/wiremock/grpc/RequestHeadersAcceptanceTest.java
+++ b/src/test/java/org/wiremock/grpc/RequestHeadersAcceptanceTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023-2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.example.grpc.GreetingServiceGrpc;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.grpc.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wiremock.grpc.client.GreetingsClient;
+import org.wiremock.grpc.dsl.WireMockGrpcService;
+
+public class RequestHeadersAcceptanceTest {
+
+  public static final String X_MY_HEADER = "x-my-Header";
+  WireMockGrpcService mockGreetingService;
+  ManagedChannel managedChannel;
+  Channel channel;
+  GreetingsClient greetingsClient;
+  WireMock wireMock;
+
+  @RegisterExtension
+  public static WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  //                  .dynamicPort()
+                  .port(8282)
+                  .withRootDirectory("src/test/resources/wiremock")
+                  .extensions(new GrpcExtensionFactory()))
+          .build();
+
+  @BeforeEach
+  void init() {
+    wireMock = wm.getRuntimeInfo().getWireMock();
+    mockGreetingService = new WireMockGrpcService(wireMock, GreetingServiceGrpc.SERVICE_NAME);
+
+    managedChannel =
+        ManagedChannelBuilder.forAddress("localhost", wm.getPort()).usePlaintext().build();
+    channel = ClientInterceptors.intercept(managedChannel, new HeaderAdditionInterceptor());
+    greetingsClient = new GreetingsClient(channel);
+  }
+
+  @AfterEach
+  void tearDown() {
+    managedChannel.shutdown();
+  }
+
+  @Test
+  void arbitraryRequestHeaderCanBeUsedWhenMatchingAndTemplating() {
+    wm.stubFor(
+        post(urlPathEqualTo("/com.example.grpc.GreetingService/greeting"))
+            .withHeader(X_MY_HEADER, equalTo("match me"))
+            .willReturn(
+                okJson(
+                        "{\n"
+                            + "    \"greeting\": \"The header value was: {{request.headers.x-my-Header}}\"\n"
+                            + "}")
+                    .withTransformers("response-template")));
+
+    String greeting = greetingsClient.greet("Whatever");
+
+    assertThat(greeting, is("The header value was: match me"));
+  }
+
+  public static class HeaderAdditionInterceptor implements ClientInterceptor {
+
+    static final Metadata.Key<String> CUSTOM_HEADER_KEY =
+        Metadata.Key.of(X_MY_HEADER, Metadata.ASCII_STRING_MARSHALLER);
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+      return new ForwardingClientCall.SimpleForwardingClientCall<>(
+          next.newCall(method, callOptions)) {
+
+        @Override
+        public void start(Listener<RespT> responseListener, Metadata headers) {
+          headers.put(CUSTOM_HEADER_KEY, "match me");
+          super.start(responseListener, headers);
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
Request headers are now visible to WireMock so they can be used for matching and templating,.