### PR TITLE
Map http status codes

### DIFF
--- a/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
@@ -18,8 +18,6 @@ package org.wiremock.grpc.internal;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_NAME;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_REASON;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
@@ -29,6 +27,7 @@ import com.google.protobuf.DynamicMessage;
 import io.grpc.Status;
 import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.http.HttpStatus;
 import org.wiremock.grpc.dsl.WireMockGrpc;
 

--- a/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
@@ -18,6 +18,9 @@ package org.wiremock.grpc.internal;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_NAME;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_REASON;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
@@ -26,7 +29,7 @@ import com.google.protobuf.DynamicMessage;
 import io.grpc.Status;
 import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
-import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.jetty.http.HttpStatus;
 import org.wiremock.grpc.dsl.WireMockGrpc;
 
 public class ClientStreamingServerCallHandler extends BaseCallHandler
@@ -69,7 +72,24 @@ public class ClientStreamingServerCallHandler extends BaseCallHandler
             (req, resp, attributes) -> {
               final HttpHeader statusHeader = resp.getHeaders().getHeader(GRPC_STATUS_NAME);
 
-              if (!statusHeader.isPresent() && resp.getStatus() == 404) {
+              // 404 needs to be handled as a special case here because when using many requests,
+              // one reply not all the requests will match.  We handle the 404 as a special case
+              // in the onCompleted method
+              if (!statusHeader.isPresent() && resp.getStatus() == HttpStatus.NOT_FOUND_404) {
+                return;
+              }
+
+              if (!statusHeader.isPresent()
+                  && GrpcStatusUtils.errorHttpToGrpcStatusMappings.containsKey(resp.getStatus())) {
+                final Pair<Status, String> statusMapping =
+                    GrpcStatusUtils.errorHttpToGrpcStatusMappings.get(resp.getStatus());
+                final Status grpcStatus = statusMapping.a;
+                final WireMockGrpc.Status status =
+                    WireMockGrpc.Status.valueOf(grpcStatus.getCode().name());
+
+                responseStatus.set(status);
+                statusReason.set(statusMapping.b);
+
                 return;
               }
 
@@ -114,10 +134,12 @@ public class ClientStreamingServerCallHandler extends BaseCallHandler
                   .withDescription(statusReason.get())
                   .asRuntimeException());
         } else {
+          final Pair<Status, String> notFoundStatusMapping =
+              GrpcStatusUtils.errorHttpToGrpcStatusMappings.get(HttpStatus.NOT_FOUND_404);
+          final Status grpcStatus = notFoundStatusMapping.a;
+
           responseObserver.onError(
-              Status.NOT_FOUND
-                  .withDescription("No matching stub mapping found for gRPC request")
-                  .asRuntimeException());
+              grpcStatus.withDescription(notFoundStatusMapping.b).asRuntimeException());
         }
       }
     };

--- a/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
@@ -23,7 +23,7 @@ import io.grpc.Status;
 public class GrpcStatusUtils {
 
   // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
-  public static final Map<Integer, Pair<Status, String>> httpToGrpcStatusMappings =
+  public static final Map<Integer, Pair<Status, String>> errorHttpToGrpcStatusMappings =
       Map.of(
           400,
           new Pair<>(Status.INTERNAL, "Bad Request"),

--- a/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
@@ -15,12 +15,13 @@
  */
 package org.wiremock.grpc.internal;
 
-import java.util.Map;
-
 import com.github.tomakehurst.wiremock.common.Pair;
 import io.grpc.Status;
+import java.util.Map;
 
 public class GrpcStatusUtils {
+
+  private GrpcStatusUtils() {}
 
   // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
   public static final Map<Integer, Pair<Status, String>> errorHttpToGrpcStatusMappings =
@@ -41,6 +42,4 @@ public class GrpcStatusUtils {
           new Pair<>(Status.UNAVAILABLE, "Service Unavailable"),
           504,
           new Pair<>(Status.UNAVAILABLE, "Gateway Timeout"));
-
-  private GrpcStatusUtils() {}
 }

--- a/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import java.util.Map;
+
+import com.github.tomakehurst.wiremock.common.Pair;
+import io.grpc.Status;
+
+public class GrpcStatusUtils {
+
+  // https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
+  public static final Map<Integer, Pair<Status, String>> httpToGrpcStatusMappings =
+      Map.of(
+          400,
+          new Pair<>(Status.INTERNAL, "Bad Request"),
+          401,
+          new Pair<>(Status.UNAUTHENTICATED, "You are not authorized to access this resource"),
+          403,
+          new Pair<>(Status.PERMISSION_DENIED, "You are not authorized to access this resource"),
+          404,
+          new Pair<>(Status.UNIMPLEMENTED, "No matching stub mapping found for gRPC request"),
+          429,
+          new Pair<>(Status.UNAVAILABLE, "Too many requests"),
+          502,
+          new Pair<>(Status.UNAVAILABLE, "Bad Gateway"),
+          503,
+          new Pair<>(Status.UNAVAILABLE, "Service Unavailable"),
+          504,
+          new Pair<>(Status.UNAVAILABLE, "Gateway Timeout"));
+
+  private GrpcStatusUtils() {}
+}

--- a/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
@@ -62,9 +62,9 @@ public class UnaryServerCallHandler extends BaseCallHandler
           delayIfRequired(resp);
 
           if (!statusHeader.isPresent()
-              && GrpcStatusUtils.httpToGrpcStatusMappings.containsKey(resp.getStatus())) {
+              && GrpcStatusUtils.errorHttpToGrpcStatusMappings.containsKey(resp.getStatus())) {
             final Pair<Status, String> statusMapping =
-                GrpcStatusUtils.httpToGrpcStatusMappings.get(resp.getStatus());
+                GrpcStatusUtils.errorHttpToGrpcStatusMappings.get(resp.getStatus());
             responseObserver.onError(
                 statusMapping.a.withDescription(statusMapping.b).asRuntimeException());
             return;

--- a/src/test/java/org/wiremock/grpc/GrpcAcceptanceTest.java
+++ b/src/test/java/org/wiremock/grpc/GrpcAcceptanceTest.java
@@ -41,12 +41,6 @@ import static org.wiremock.grpc.dsl.WireMockGrpc.message;
 import static org.wiremock.grpc.dsl.WireMockGrpc.messageAsAny;
 import static org.wiremock.grpc.dsl.WireMockGrpc.method;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.stream.Stream;
-
 import com.example.grpc.AnotherGreetingServiceGrpc;
 import com.example.grpc.GreetingServiceGrpc;
 import com.example.grpc.request.HelloRequest;
@@ -64,6 +58,11 @@ import io.grpc.reflection.v1.ServerReflectionRequest;
 import io.grpc.reflection.v1.ServerReflectionResponse;
 import io.grpc.reflection.v1.ServiceResponse;
 import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR maps the http error codes detailed in the [official docs](https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md) to their corresponding grpc status codes.

## References

- https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
