### PR TITLE
only run snyk scan on main.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,6 +59,7 @@ jobs:
   gradle-scan:
     name: Snyk gradle scan
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
prs from forks fail the snyk scan due to not having access to the token, so only running on main is a better option than always failing prs from forks.