### PR TITLE
add_includeDefaultValueFields_flag

### DIFF
--- a/src/main/java/org/wiremock/grpc/internal/JsonMessageConverter.java
+++ b/src/main/java/org/wiremock/grpc/internal/JsonMessageConverter.java
@@ -32,7 +32,12 @@ public class JsonMessageConverter {
   }
 
   public String toJson(MessageOrBuilder message) {
-    return Exceptions.uncheck(() -> jsonPrinter.print(message), String.class);
+    if ("true".equals(System.getenv("GRPC_JSON_PRINTER_INCLUDE_ALL_DEFAULT_VALUE_FIELDS"))) {
+      return Exceptions.uncheck(
+          () -> jsonPrinter.includingDefaultValueFields().print(message), String.class);
+    } else {
+      return Exceptions.uncheck(() -> jsonPrinter.print(message), String.class);
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
There are many situations, where you need to have all fields with default values being contained to json
So there is a flag, which allow you to do it. Its easy to do it for example in docker-compose:

![image](https://github.com/user-attachments/assets/ef3a5b10-8088-4b7d-b553-ded4585200a5)

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
