### PR TITLE
fix: reference to the correct branch for pushing snapshots

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,7 +2,7 @@ name: Publish Snapshots
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
   workflow_dispatch:
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR fixes the reference to the branch for when to create a snapshot `master` -> `main`

