### PR TITLE
Support returning multiple streaming responses for a unary gRPC request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ dependencies {
   testFixturesApi "org.hamcrest:hamcrest-core:3.0"
   testFixturesApi "org.hamcrest:hamcrest-library:3.0"
   testFixturesApi 'org.awaitility:awaitility:4.2.2'
+  testFixturesApi 'org.slf4j:slf4j-simple:2.0.16'
 
   testFixturesApi "io.grpc:grpc-okhttp"
 

--- a/src/main/java/org/wiremock/grpc/dsl/WireMockGrpc.java
+++ b/src/main/java/org/wiremock/grpc/dsl/WireMockGrpc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.protobuf.MessageOrBuilder;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.wiremock.annotations.Beta;
 import org.wiremock.grpc.internal.JsonMessageUtils;
 
@@ -47,6 +49,17 @@ public class WireMockGrpc {
 
   public static GrpcResponseDefinitionBuilder message(MessageOrBuilder messageOrBuilder) {
     final String json = JsonMessageUtils.toJson(messageOrBuilder);
+    return new GrpcResponseDefinitionBuilder(Status.OK).fromJson(json);
+  }
+
+  public static GrpcResponseDefinitionBuilder messages(
+      List<MessageOrBuilder> messageOrBuilderList) {
+    final String json =
+        "[\n"
+            + messageOrBuilderList.stream()
+                .map(JsonMessageUtils::toJson)
+                .collect(Collectors.joining(",\n"))
+            + "\n]";
     return new GrpcResponseDefinitionBuilder(Status.OK).fromJson(json);
   }
 

--- a/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_NA
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_REASON;
 import static org.wiremock.grpc.internal.Delays.delayIfRequired;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
@@ -28,10 +31,13 @@ import com.google.protobuf.DynamicMessage;
 import io.grpc.Status;
 import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import org.wiremock.grpc.dsl.WireMockGrpc;
 
 public class UnaryServerCallHandler extends BaseCallHandler
     implements ServerCalls.UnaryMethod<DynamicMessage, DynamicMessage> {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   public UnaryServerCallHandler(
       StubRequestHandler stubRequestHandler,
@@ -85,12 +91,26 @@ public class UnaryServerCallHandler extends BaseCallHandler
             return;
           }
 
-          DynamicMessage.Builder messageBuilder =
-              DynamicMessage.newBuilder(methodDescriptor.getOutputType());
+          try (MappingIterator<JsonNode> iterator =
+              objectMapper.readerFor(JsonNode.class).readValues(resp.getBody())) {
 
-          final DynamicMessage response =
-              jsonMessageConverter.toMessage(resp.getBodyAsString(), messageBuilder);
-          responseObserver.onNext(response);
+            while (iterator.hasNext()) {
+              JsonNode node = iterator.next();
+
+              final DynamicMessage.Builder messageBuilder =
+                  DynamicMessage.newBuilder(methodDescriptor.getOutputType());
+              final DynamicMessage response =
+                  jsonMessageConverter.toMessage(node.toString(), messageBuilder);
+
+              responseObserver.onNext(response);
+            }
+          } catch (IOException e) {
+            responseObserver.onError(
+                Status.INTERNAL
+                    .withDescription("Error parsing response")
+                    .withCause(e)
+                    .asRuntimeException());
+          }
           responseObserver.onCompleted();
         },
         ServeEvent.of(wireMockRequest));

--- a/src/test/java/org/wiremock/grpc/GrpcAcceptanceTest.java
+++ b/src/test/java/org/wiremock/grpc/GrpcAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
@@ -39,6 +40,7 @@ import static org.wiremock.grpc.dsl.WireMockGrpc.json;
 import static org.wiremock.grpc.dsl.WireMockGrpc.jsonTemplate;
 import static org.wiremock.grpc.dsl.WireMockGrpc.message;
 import static org.wiremock.grpc.dsl.WireMockGrpc.messageAsAny;
+import static org.wiremock.grpc.dsl.WireMockGrpc.messages;
 import static org.wiremock.grpc.dsl.WireMockGrpc.method;
 
 import com.example.grpc.AnotherGreetingServiceGrpc;
@@ -282,12 +284,25 @@ public class GrpcAcceptanceTest {
   }
 
   @Test
-  void returnsStreamedResponseToUnaryRequest() {
+  void returnsStreamedResponseToUnaryRequestWithSingleItem() {
     mockGreetingService.stubFor(
         method("oneGreetingManyReplies")
             .willReturn(message(HelloResponse.newBuilder().setGreeting("Hi Tom"))));
 
     assertThat(greetingsClient.oneGreetingManyReplies("Tom"), hasItem("Hi Tom"));
+  }
+
+  @Test
+  void returnsStreamedResponseToUnaryRequest() {
+    mockGreetingService.stubFor(
+        method("oneGreetingManyReplies")
+            .willReturn(
+                messages(
+                    List.of(
+                        HelloResponse.newBuilder().setGreeting("Hi Tom"),
+                        HelloResponse.newBuilder().setGreeting("Hi Tom again")))));
+
+    assertThat(greetingsClient.oneGreetingManyReplies("Tom"), hasItems("Hi Tom", "Hi Tom again"));
   }
 
   @Test
@@ -337,7 +352,7 @@ public class GrpcAcceptanceTest {
 
     Exception exception =
         assertThrows(StatusRuntimeException.class, () -> greetingsClient.greet("Alan"));
-    assertThat(exception.getMessage(), startsWith("UNKNOWN"));
+    assertThat(exception.getMessage(), startsWith("CANCELLED"));
   }
 
   @Test


### PR DESCRIPTION
Support returning multiple streaming responses for a unary gRPC request.

## Implementation

The JSON response is parsed into a JSON tree using Jackson's MappingIterator. Each JSON document is then mapped to a gRPC response as before and emitted using the gRPC stub response observer.

## References

https://github.com/wiremock/wiremock-grpc-extension/issues/55

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
