### PR TITLE
Enable gPRC proxy renderer while recording gRPC traffic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ dependencies {
   api "io.grpc:grpc-protobuf"
   api "io.grpc:grpc-services"
   api "io.grpc:grpc-stub"
+  api "io.grpc:grpc-netty"
 
   implementation "io.grpc:grpc-servlet-jakarta"
   implementation "com.google.protobuf:protobuf-java-util:$versions.protobuf"

--- a/src/main/java/org/wiremock/grpc/GrpcExtensionFactory.java
+++ b/src/main/java/org/wiremock/grpc/GrpcExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,15 @@ import com.github.tomakehurst.wiremock.extension.WireMockServices;
 import com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader;
 import java.util.List;
 import org.wiremock.grpc.internal.GrpcHttpServerFactory;
+import org.wiremock.grpc.internal.GrpcResponseRendererFactory;
 
 public class GrpcExtensionFactory implements ExtensionFactory {
 
   @Override
   public List<Extension> create(WireMockServices services) {
-    return List.of(new GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")));
+    return List.of(
+        new GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")),
+        new GrpcResponseRendererFactory());
   }
 
   @Override

--- a/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,11 @@ public class ClientStreamingServerCallHandler extends BaseCallHandler
                 serverAddress.port,
                 serviceDescriptor.getFullName(),
                 methodDescriptor.getName(),
-                jsonMessageConverter.toJson(request));
+                jsonMessageConverter.toJson(request),
+                serviceDescriptor,
+                methodDescriptor,
+                jsonMessageConverter,
+                request);
 
         stubRequestHandler.handle(
             wireMockRequest,

--- a/src/main/java/org/wiremock/grpc/internal/GrpcRequest.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import static java.util.Collections.*;
 import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.common.Strings;
 import com.github.tomakehurst.wiremock.http.*;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -32,17 +34,33 @@ public class GrpcRequest implements Request {
   private final int port;
   private final String serviceName;
   private final String methodName;
-
   private final String body;
+  private final Descriptors.ServiceDescriptor serviceDescriptor;
+  private final Descriptors.MethodDescriptor methodDescriptor;
+  private final JsonMessageConverter jsonMessageConverter;
+  private final DynamicMessage dynamicMessage;
 
   public GrpcRequest(
-      String scheme, String host, int port, String serviceName, String methodName, String body) {
+      String scheme,
+      String host,
+      int port,
+      String serviceName,
+      String methodName,
+      String body,
+      Descriptors.ServiceDescriptor serviceDescriptor,
+      Descriptors.MethodDescriptor methodDescriptor,
+      JsonMessageConverter jsonMessageConverter,
+      DynamicMessage dynamicMessage) {
     this.scheme = scheme;
     this.host = host;
     this.port = port;
     this.serviceName = serviceName;
     this.methodName = methodName;
     this.body = body;
+    this.serviceDescriptor = serviceDescriptor;
+    this.methodDescriptor = methodDescriptor;
+    this.jsonMessageConverter = jsonMessageConverter;
+    this.dynamicMessage = dynamicMessage;
   }
 
   @Override
@@ -173,5 +191,21 @@ public class GrpcRequest implements Request {
   @Override
   public String getProtocol() {
     return "HTTP/2";
+  }
+
+  public Descriptors.ServiceDescriptor getServiceDescriptor() {
+    return serviceDescriptor;
+  }
+
+  public Descriptors.MethodDescriptor getMethodDescriptor() {
+    return methodDescriptor;
+  }
+
+  public DynamicMessage getDynamicMessage() {
+    return dynamicMessage;
+  }
+
+  public JsonMessageConverter getJsonMessageConverter() {
+    return jsonMessageConverter;
   }
 }

--- a/src/main/java/org/wiremock/grpc/internal/GrpcResponseRenderer.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcResponseRenderer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import static com.github.tomakehurst.wiremock.http.Response.response;
+
+import com.github.tomakehurst.wiremock.extension.ProxyRenderer;
+import com.github.tomakehurst.wiremock.global.GlobalSettings;
+import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.store.SettingsStore;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.google.protobuf.DynamicMessage;
+import io.grpc.*;
+import io.grpc.stub.ClientCalls;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GrpcResponseRenderer implements ProxyRenderer {
+  private final SettingsStore settingsStore;
+  private final boolean stubCorsEnabled;
+
+  public GrpcResponseRenderer(SettingsStore settingsStore, boolean stubCorsEnabled) {
+    this.settingsStore = settingsStore;
+    this.stubCorsEnabled = stubCorsEnabled;
+  }
+
+  @Override
+  public boolean applyFor(ServeEvent serveEvent) {
+    ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
+    Request originalRequest = responseDefinition.getOriginalRequest();
+    return originalRequest instanceof GrpcRequest;
+  }
+
+  @Override
+  public int Order() {
+    return 0;
+  }
+
+  @Override
+  public Response render(ServeEvent serveEvent) {
+    ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
+    GrpcRequest grpcRequest = (GrpcRequest) responseDefinition.getOriginalRequest();
+    GlobalSettings settings = settingsStore.get();
+
+    URI uri = URI.create(responseDefinition.getProxyBaseUrl());
+    Channel channel =
+        ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort()).usePlaintext().build();
+    List<HttpHeader> headers = new ArrayList<>();
+    headers.add(new HttpHeader("Content-Type", grpcRequest.getHeader("Content-Type")));
+    Response.Builder grpcRespBuilder = response();
+    String statusName = Status.Code.OK.name();
+    String statusReason = null;
+    try {
+      DynamicMessage responseMsg =
+          ClientCalls.blockingUnaryCall(
+              channel,
+              GrpcUtils.buildMessageDescriptorInstance(
+                  grpcRequest.getServiceDescriptor(), grpcRequest.getMethodDescriptor()),
+              CallOptions.DEFAULT,
+              grpcRequest.getDynamicMessage());
+      JsonMessageConverter converter = grpcRequest.getJsonMessageConverter();
+      String jsonStr = converter.toJson(responseMsg);
+      headers.add(new HttpHeader(GrpcUtils.GRPC_STATUS_NAME, statusName));
+      grpcRespBuilder.status(200).body(jsonStr);
+    } catch (Exception e) {
+      Status grpcStatus = null;
+      if (e instanceof StatusRuntimeException) {
+        StatusRuntimeException stsEx = (StatusRuntimeException) e;
+        grpcStatus = stsEx.getStatus();
+        statusName = grpcStatus.getCode().name();
+        statusReason = grpcStatus.getDescription();
+      } else {
+        grpcStatus = Status.INTERNAL;
+        statusName = Status.Code.INTERNAL.name();
+        statusReason = e.getMessage();
+      }
+
+      Integer httpStatus = GrpcStatusUtils.reverseMappings.get(grpcStatus);
+      if (httpStatus != null) {
+        grpcRespBuilder.status(httpStatus);
+      } else {
+        grpcRespBuilder.status(500);
+      }
+      headers.add(new HttpHeader(GrpcUtils.GRPC_STATUS_NAME, statusName));
+      headers.add(new HttpHeader(GrpcUtils.GRPC_STATUS_REASON, statusReason));
+    }
+
+    Response httpResponse =
+        grpcRespBuilder.headers(new HttpHeaders(headers.toArray(HttpHeader[]::new))).build();
+    return Response.Builder.like(httpResponse)
+        .fromProxy(true)
+        .headers(HeaderUtil.headersFrom(httpResponse, responseDefinition, stubCorsEnabled))
+        .configureDelay(
+            settings.getFixedDelay(),
+            settings.getDelayDistribution(),
+            responseDefinition.getFixedDelayMilliseconds(),
+            responseDefinition.getDelayDistribution())
+        .chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay())
+        .build();
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/GrpcResponseRendererFactory.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcResponseRendererFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.extension.ProxyRenderer;
+import com.github.tomakehurst.wiremock.extension.ProxyRendererFactory;
+
+public class GrpcResponseRendererFactory implements ProxyRendererFactory {
+  @Override
+  public ProxyRenderer build(Options options) {
+    return new GrpcResponseRenderer(
+        options.getStores().getSettingsStore(), options.getStubCorsEnabled());
+  }
+
+  @Override
+  public String getName() {
+    return "GrpcProxyResponseRendererFactory";
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,4 +42,12 @@ public class GrpcStatusUtils {
           new Pair<>(Status.UNAVAILABLE, "Service Unavailable"),
           504,
           new Pair<>(Status.UNAVAILABLE, "Gateway Timeout"));
+
+  public static final Map<Status, Integer> reverseMappings =
+      Map.of(
+          Status.INTERNAL, 400,
+          Status.UNAUTHENTICATED, 401,
+          Status.PERMISSION_DENIED, 403,
+          Status.UNIMPLEMENTED, 404,
+          Status.UNAVAILABLE, 504);
 }

--- a/src/main/java/org/wiremock/grpc/internal/GrpcUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+
+public class GrpcUtils {
+  public static final String GRPC_STATUS_NAME = "grpc-status-name";
+  public static final String GRPC_STATUS_REASON = "grpc-status-reason";
+
+  public static MethodDescriptor<DynamicMessage, DynamicMessage> buildMessageDescriptorInstance(
+      Descriptors.ServiceDescriptor serviceDescriptor,
+      Descriptors.MethodDescriptor methodDescriptor) {
+    return MethodDescriptor.<DynamicMessage, DynamicMessage>newBuilder()
+        .setType(getMethodTypeFromDesc(methodDescriptor))
+        .setFullMethodName(
+            MethodDescriptor.generateFullMethodName(
+                serviceDescriptor.getFullName(), methodDescriptor.getName()))
+        .setRequestMarshaller(
+            ProtoUtils.marshaller(
+                DynamicMessage.getDefaultInstance(methodDescriptor.getInputType())))
+        .setResponseMarshaller(
+            ProtoUtils.marshaller(
+                DynamicMessage.getDefaultInstance(methodDescriptor.getOutputType())))
+        .build();
+  }
+
+  public static MethodDescriptor.MethodType getMethodTypeFromDesc(
+      Descriptors.MethodDescriptor methodDesc) {
+    if (!methodDesc.isServerStreaming() && !methodDesc.isClientStreaming()) {
+      return MethodDescriptor.MethodType.UNARY;
+    } else if (methodDesc.isServerStreaming() && !methodDesc.isClientStreaming()) {
+      return MethodDescriptor.MethodType.SERVER_STREAMING;
+    } else if (!methodDesc.isServerStreaming()) {
+      return MethodDescriptor.MethodType.CLIENT_STREAMING;
+    } else {
+      return MethodDescriptor.MethodType.BIDI_STREAMING;
+    }
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,11 @@ public class UnaryServerCallHandler extends BaseCallHandler
             serverAddress.port,
             serviceDescriptor.getFullName(),
             methodDescriptor.getName(),
-            jsonMessageConverter.toJson(request));
+            jsonMessageConverter.toJson(request),
+            serviceDescriptor,
+            methodDescriptor,
+            jsonMessageConverter,
+            request);
 
     stubRequestHandler.handle(
         wireMockRequest,

--- a/wiremock-grpc-extension-standalone/build.gradle
+++ b/wiremock-grpc-extension-standalone/build.gradle
@@ -152,6 +152,7 @@ shadowJar {
   exclude 'META-INF/versions/22/**'
   exclude 'module-info.class'
   exclude 'handlebars-*.js'
+  mergeServiceFiles()
 }
 
 protobuf {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
