### PR TITLE
enable gRPC for recording

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ dependencies {
   api "io.grpc:grpc-protobuf"
   api "io.grpc:grpc-services"
   api "io.grpc:grpc-stub"
+  api "io.grpc:grpc-netty"
 
   implementation "io.grpc:grpc-servlet-jakarta"
   implementation "com.google.protobuf:protobuf-java-util:$versions.protobuf"

--- a/src/main/java/org/wiremock/grpc/GrpcExtensionFactory.java
+++ b/src/main/java/org/wiremock/grpc/GrpcExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,18 @@ import com.github.tomakehurst.wiremock.extension.ExtensionFactory;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
 import com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader;
 import java.util.List;
+import org.wiremock.grpc.internal.GrpcHttpClientFactory;
 import org.wiremock.grpc.internal.GrpcHttpServerFactory;
+import org.wiremock.grpc.internal.GrpcStubMappingTransformer;
 
 public class GrpcExtensionFactory implements ExtensionFactory {
 
   @Override
   public List<Extension> create(WireMockServices services) {
-    return List.of(new GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")));
+    return List.of(
+        new GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")),
+        new GrpcHttpClientFactory(),
+        new GrpcStubMappingTransformer());
   }
 
   @Override

--- a/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/ClientStreamingServerCallHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,9 @@ public class ClientStreamingServerCallHandler extends BaseCallHandler
         if (firstResponse.get() != null) {
           return;
         }
+
+        BaseCallHandler.CONTEXT.set(
+            new GrpcContext(serviceDescriptor, methodDescriptor, jsonMessageConverter, request));
 
         final GrpcRequest wireMockRequest =
             new GrpcRequest(

--- a/src/main/java/org/wiremock/grpc/internal/GrpcClient.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcClient.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import static com.github.tomakehurst.wiremock.http.Response.response;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.http.client.ApacheHttpClientFactory;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
+import com.google.protobuf.DynamicMessage;
+import io.grpc.*;
+import io.grpc.stub.ClientCalls;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GrpcClient implements HttpClient {
+  private final HttpClient delegateClient;
+
+  public GrpcClient(
+      Options options,
+      boolean trustAllCertificates,
+      List<String> trustedHosts,
+      boolean useSystemProperties) {
+    this.delegateClient =
+        new ApacheHttpClientFactory()
+            .buildHttpClient(options, trustAllCertificates, trustedHosts, useSystemProperties);
+  }
+
+  @Override
+  public Response execute(Request request) throws IOException {
+    String contentType = request.getHeader("Content-Type");
+    if (!"application/grpc".equalsIgnoreCase(contentType)) {
+      return delegateClient.execute(request);
+    }
+
+    GrpcContext context = BaseCallHandler.CONTEXT.get();
+    BaseCallHandler.CONTEXT.remove();
+
+    Channel channel =
+        ManagedChannelBuilder.forAddress(request.getHost(), request.getPort())
+            .usePlaintext()
+            .build();
+    List<HttpHeader> headers = new ArrayList<>();
+    headers.add(new HttpHeader("Content-Type", request.getHeader("Content-Type")));
+    Response.Builder grpcRespBuilder = response();
+    String statusName = Status.Code.OK.name();
+    String statusReason = null;
+    try {
+      DynamicMessage responseMsg =
+          ClientCalls.blockingUnaryCall(
+              channel,
+              GrpcUtils.buildMessageDescriptorInstance(
+                  context.getServiceDescriptor(), context.getMethodDescriptor()),
+              CallOptions.DEFAULT,
+              context.getDm());
+      JsonMessageConverter converter = context.getJsonMessageConverter();
+      String jsonStr = converter.toJson(responseMsg);
+      headers.add(new HttpHeader(GrpcUtils.GRPC_STATUS_NAME, statusName));
+      grpcRespBuilder.status(200).body(jsonStr);
+    } catch (Exception e) {
+      Status grpcStatus = null;
+      if (e instanceof StatusRuntimeException) {
+        StatusRuntimeException stsEx = (StatusRuntimeException) e;
+        grpcStatus = stsEx.getStatus();
+        statusName = grpcStatus.getCode().name();
+        statusReason = grpcStatus.getDescription();
+      } else {
+        grpcStatus = Status.INTERNAL;
+        statusName = Status.Code.INTERNAL.name();
+        statusReason = e.getMessage();
+      }
+
+      Integer httpStatus = GrpcStatusUtils.reverseMappings.get(grpcStatus);
+      if (httpStatus != null) {
+        grpcRespBuilder.status(httpStatus);
+      } else {
+        grpcRespBuilder.status(500);
+      }
+      headers.add(new HttpHeader(GrpcUtils.GRPC_STATUS_NAME, statusName));
+      headers.add(new HttpHeader(GrpcUtils.GRPC_STATUS_REASON, statusReason));
+    }
+
+    return grpcRespBuilder.headers(new HttpHeaders(headers.toArray(HttpHeader[]::new))).build();
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/GrpcContext.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 Thomas Akehurst
+ * Copyright (C) 2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,25 +15,39 @@
  */
 package org.wiremock.grpc.internal;
 
-import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 
-public abstract class BaseCallHandler {
-  public static final ThreadLocal<GrpcContext> CONTEXT = new ThreadLocal<>();
-  protected final StubRequestHandler stubRequestHandler;
-  protected final Descriptors.ServiceDescriptor serviceDescriptor;
-  protected final Descriptors.MethodDescriptor methodDescriptor;
+public class GrpcContext {
+  private final Descriptors.ServiceDescriptor serviceDescriptor;
+  private final Descriptors.MethodDescriptor methodDescriptor;
+  private final JsonMessageConverter jsonMessageConverter;
+  private final DynamicMessage dm;
 
-  protected final JsonMessageConverter jsonMessageConverter;
-
-  protected BaseCallHandler(
-      StubRequestHandler stubRequestHandler,
+  public GrpcContext(
       Descriptors.ServiceDescriptor serviceDescriptor,
       Descriptors.MethodDescriptor methodDescriptor,
-      JsonMessageConverter jsonMessageConverter) {
-    this.stubRequestHandler = stubRequestHandler;
+      JsonMessageConverter jsonMessageConverter,
+      DynamicMessage dm) {
     this.serviceDescriptor = serviceDescriptor;
     this.methodDescriptor = methodDescriptor;
     this.jsonMessageConverter = jsonMessageConverter;
+    this.dm = dm;
+  }
+
+  public Descriptors.ServiceDescriptor getServiceDescriptor() {
+    return serviceDescriptor;
+  }
+
+  public Descriptors.MethodDescriptor getMethodDescriptor() {
+    return methodDescriptor;
+  }
+
+  public JsonMessageConverter getJsonMessageConverter() {
+    return jsonMessageConverter;
+  }
+
+  public DynamicMessage getDm() {
+    return dm;
   }
 }

--- a/src/main/java/org/wiremock/grpc/internal/GrpcHttpClientFactory.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcHttpClientFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.client.HttpClient;
+import com.github.tomakehurst.wiremock.http.client.HttpClientFactory;
+import java.util.List;
+
+public class GrpcHttpClientFactory implements HttpClientFactory {
+
+  @Override
+  public String getName() {
+    return "grpc-client-factory";
+  }
+
+  @Override
+  public HttpClient buildHttpClient(
+      Options options,
+      boolean trustAllCertificates,
+      List<String> trustedHosts,
+      boolean useSystemProperties) {
+    return new GrpcClient(options, trustAllCertificates, trustedHosts, useSystemProperties);
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcStatusUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Thomas Akehurst
+ * Copyright (C) 2024-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,4 +42,12 @@ public class GrpcStatusUtils {
           new Pair<>(Status.UNAVAILABLE, "Service Unavailable"),
           504,
           new Pair<>(Status.UNAVAILABLE, "Gateway Timeout"));
+
+  public static final Map<Status, Integer> reverseMappings =
+      Map.of(
+          Status.INTERNAL, 400,
+          Status.UNAUTHENTICATED, 401,
+          Status.PERMISSION_DENIED, 403,
+          Status.UNIMPLEMENTED, 404,
+          Status.UNAVAILABLE, 504);
 }

--- a/src/main/java/org/wiremock/grpc/internal/GrpcStubMappingTransformer.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcStubMappingTransformer.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.Encoding;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.StubMappingTransformer;
+import com.github.tomakehurst.wiremock.http.Body;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.matching.*;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import java.nio.charset.StandardCharsets;
+
+public class GrpcStubMappingTransformer extends StubMappingTransformer {
+  @Override
+  public StubMapping transform(StubMapping stubMapping, FileSource files, Parameters parameters) {
+    ResponseDefinition resp = stubMapping.getResponse();
+    if (resp.getHeaders() != null
+        && resp.getHeaders().getContentTypeHeader() != null
+        && resp.getHeaders().getContentTypeHeader().getValues().contains("application/grpc")) {
+      // when response is grpc, we need to convert the response body to json
+      ResponseDefinition jsonResp = convertBinaryToJson(resp);
+      stubMapping.setResponse(jsonResp);
+
+      // when response is grpc, we need to convert the request body to json as well
+      RequestPattern req = stubMapping.getRequest();
+      RequestPattern jsonReq = convertBinaryToJson(req);
+      stubMapping.setRequest(jsonReq);
+    }
+    return stubMapping;
+  }
+
+  private ResponseDefinition convertBinaryToJson(ResponseDefinition resp) {
+    String base64Body = resp.getBase64Body();
+    if (base64Body != null) {
+      byte[] rawBytes = Encoding.decodeBase64(base64Body);
+      return ResponseDefinitionBuilder.like(resp)
+          .but()
+          .withBase64Body(null)
+          .withJsonBody(Body.fromJsonBytes(rawBytes).asJson())
+          .build();
+    } else {
+      return resp;
+    }
+  }
+
+  private RequestPattern convertBinaryToJson(RequestPattern req) {
+    RequestPatternBuilder reqBuilder =
+        RequestPatternBuilder.newRequestPattern(req.getMethod(), req.getUrlMatcher())
+            .withScheme(req.getScheme())
+            .withHost(req.getHost());
+    if (req.getPort() != null) {
+      reqBuilder.withPort(req.getPort());
+    }
+    if (req.getHeaders() != null) {
+      req.getHeaders().forEach(reqBuilder::withHeader);
+    }
+    if (req.getPathParameters() != null) {
+      req.getPathParameters().forEach(reqBuilder::withPathParam);
+    }
+    if (req.getQueryParameters() != null) {
+      req.getQueryParameters().forEach(reqBuilder::withQueryParam);
+    }
+    if (req.getFormParameters() != null) {
+      req.getFormParameters().forEach(reqBuilder::withFormParam);
+    }
+    if (req.getCookies() != null) {
+      req.getCookies().forEach(reqBuilder::withCookie);
+    }
+    if (req.getBodyPatterns() != null) {
+      req.getBodyPatterns()
+          .forEach(
+              body -> {
+                if (body instanceof BinaryEqualToPattern) {
+                  BinaryEqualToPattern binaryPattern = (BinaryEqualToPattern) body;
+                  byte[] bytes = binaryPattern.getValue();
+                  reqBuilder.withRequestBody(
+                      new EqualToJsonPattern(
+                          new String(bytes, StandardCharsets.UTF_8), true, false));
+                } else {
+                  reqBuilder.withRequestBody(body);
+                }
+              });
+    }
+    if (req.hasInlineCustomMatcher()) {
+      reqBuilder.andMatching(req.getMatcher());
+    }
+    if (req.getMultipartPatterns() != null) {
+      req.getMultipartPatterns().forEach(reqBuilder::withRequestBodyPart);
+    }
+    reqBuilder.withBasicAuth(req.getBasicAuthCredentials());
+    reqBuilder.andMatching(req.getCustomMatcher());
+    return reqBuilder.build();
+  }
+
+  @Override
+  public String getName() {
+    return "grpc-stub-transformer";
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/GrpcUtils.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wiremock.grpc.internal;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import io.grpc.MethodDescriptor;
+import io.grpc.protobuf.ProtoUtils;
+
+public class GrpcUtils {
+  public static final String GRPC_STATUS_NAME = "grpc-status-name";
+  public static final String GRPC_STATUS_REASON = "grpc-status-reason";
+
+  public static MethodDescriptor<DynamicMessage, DynamicMessage> buildMessageDescriptorInstance(
+      Descriptors.ServiceDescriptor serviceDescriptor,
+      Descriptors.MethodDescriptor methodDescriptor) {
+    return MethodDescriptor.<DynamicMessage, DynamicMessage>newBuilder()
+        .setType(getMethodTypeFromDesc(methodDescriptor))
+        .setFullMethodName(
+            MethodDescriptor.generateFullMethodName(
+                serviceDescriptor.getFullName(), methodDescriptor.getName()))
+        .setRequestMarshaller(
+            ProtoUtils.marshaller(
+                DynamicMessage.getDefaultInstance(methodDescriptor.getInputType())))
+        .setResponseMarshaller(
+            ProtoUtils.marshaller(
+                DynamicMessage.getDefaultInstance(methodDescriptor.getOutputType())))
+        .build();
+  }
+
+  public static MethodDescriptor.MethodType getMethodTypeFromDesc(
+      Descriptors.MethodDescriptor methodDesc) {
+    if (!methodDesc.isServerStreaming() && !methodDesc.isClientStreaming()) {
+      return MethodDescriptor.MethodType.UNARY;
+    } else if (methodDesc.isServerStreaming() && !methodDesc.isClientStreaming()) {
+      return MethodDescriptor.MethodType.SERVER_STREAMING;
+    } else if (!methodDesc.isServerStreaming()) {
+      return MethodDescriptor.MethodType.CLIENT_STREAMING;
+    } else {
+      return MethodDescriptor.MethodType.BIDI_STREAMING;
+    }
+  }
+}

--- a/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,9 @@ public class UnaryServerCallHandler extends BaseCallHandler
   @Override
   public void invoke(DynamicMessage request, StreamObserver<DynamicMessage> responseObserver) {
     final GrpcFilter.ServerAddress serverAddress = GrpcFilter.ServerAddress.get();
+
+    CONTEXT.set(
+        new GrpcContext(serviceDescriptor, methodDescriptor, jsonMessageConverter, request));
 
     final GrpcRequest wireMockRequest =
         new GrpcRequest(

--- a/wiremock-grpc-extension-jetty12/src/main/java/org/wiremock/grpc/Jetty12GrpcExtensionFactory.java
+++ b/wiremock-grpc-extension-jetty12/src/main/java/org/wiremock/grpc/Jetty12GrpcExtensionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Thomas Akehurst
+ * Copyright (C) 2023-2025 Thomas Akehurst
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +18,24 @@ package org.wiremock.grpc;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionFactory;
 import com.github.tomakehurst.wiremock.extension.WireMockServices;
-import java.util.List;
-
 import com.github.tomakehurst.wiremock.http.HttpServerFactoryLoader;
-import org.wiremock.annotations.Beta;
-import org.wiremock.grpc.internal.GrpcAdminApiExtension;
+import java.util.List;
+import org.wiremock.grpc.internal.GrpcHttpClientFactory;
 import org.wiremock.grpc.internal.GrpcHttpServerFactory;
-import org.wiremock.grpc.internal.Jetty12GrpcHttpServerFactory;
+import org.wiremock.grpc.internal.GrpcStubMappingTransformer;
 
-@Beta(justification = "Incubating extension: https://github.com/wiremock/wiremock/issues/2383")
-public class Jetty12GrpcExtensionFactory implements ExtensionFactory {
+public class GrpcExtensionFactory implements ExtensionFactory {
 
-  @Override
-  public List<Extension> create(WireMockServices services) {
-      return List.of(new Jetty12GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")));
-  }
+    @Override
+    public List<Extension> create(WireMockServices services) {
+        return List.of(
+                new GrpcHttpServerFactory(services.getStores().getBlobStore("grpc")),
+                new GrpcHttpClientFactory(),
+                new GrpcStubMappingTransformer());
+    }
 
     @Override
     public boolean isLoadable() {
-        return !HttpServerFactoryLoader.isJetty11();
+        return HttpServerFactoryLoader.isJetty11();
     }
 }

--- a/wiremock-grpc-extension-standalone/build.gradle
+++ b/wiremock-grpc-extension-standalone/build.gradle
@@ -153,6 +153,7 @@ shadowJar {
   exclude 'META-INF/versions/22/**'
   exclude 'module-info.class'
   exclude 'handlebars-*.js'
+  mergeServiceFiles()
 }
 
 protobuf {


### PR DESCRIPTION
This is a new PR for the same requirement of supporting gRPC in recording. 
The PR is based on the feedback here: https://github.com/wiremock/wiremock-grpc-extension/pull/143.

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
