### PR TITLE
Constrained Netty to a version not affected by SNYK-JAVA-IONETTY-8707739

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,10 @@ dependencies {
     exclude group: 'org.eclipse.jetty'
     exclude group: 'org.eclipse.jetty.http2'
   })
+
+  constraints {
+    implementation "io.netty:netty-codec-http2:4.2.0.RC3"
+  }
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Fix for the following Snyk report:

```
Issues with no direct upgrade or patch:
  ✗ Improper Validation of Specified Quantity in Input [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-8707739] in io.netty:netty-handler@4.1.110.Final
    introduced by io.grpc:grpc-netty@1.73.0 > io.netty:netty-codec-http2@4.1.110.Final > io.netty:netty-handler@4.1.110.Final and 1 other path(s)
  This issue was fixed in versions: 4.1.1[18](https://github.com/wiremock/wiremock-grpc-extension/actions/runs/15486692053/job/43602874540#step:4:19).Final, 4.2.0.RC3
```