### PR TITLE
Copy response http headers into grpc headers

### DIFF
--- a/src/main/java/org/wiremock/grpc/internal/GrpcRequest.java
+++ b/src/main/java/org/wiremock/grpc/internal/GrpcRequest.java
@@ -97,7 +97,7 @@ public class GrpcRequest implements Request {
 
   @Override
   public HttpHeaders getHeaders() {
-    return HeaderCopyingServerInterceptor.HTTP_HEADERS_CONTEXT_KEY.get();
+    return HeaderCopyingServerInterceptor.HTTP_REQUEST_HEADERS_CONTEXT_KEY.get();
   }
 
   @Override

--- a/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
+++ b/src/main/java/org/wiremock/grpc/internal/UnaryServerCallHandler.java
@@ -18,9 +18,11 @@ package org.wiremock.grpc.internal;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_NAME;
 import static org.wiremock.grpc.dsl.GrpcResponseDefinitionBuilder.GRPC_STATUS_REASON;
 import static org.wiremock.grpc.internal.Delays.delayIfRequired;
+import static org.wiremock.grpc.internal.HeaderCopyingServerInterceptor.HTTP_RESPONSE_HEADERS_CONTEXT_KEY;
 
 import com.github.tomakehurst.wiremock.common.Pair;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.google.protobuf.Descriptors;
@@ -60,7 +62,10 @@ public class UnaryServerCallHandler extends BaseCallHandler
     stubRequestHandler.handle(
         wireMockRequest,
         (req, resp, attributes) -> {
-          final HttpHeader statusHeader = resp.getHeaders().getHeader(GRPC_STATUS_NAME);
+          HttpHeaders respHeaders = resp.getHeaders();
+          HTTP_RESPONSE_HEADERS_CONTEXT_KEY.get().set(respHeaders);
+
+          final HttpHeader statusHeader = respHeaders.getHeader(GRPC_STATUS_NAME);
 
           delayIfRequired(resp);
 
@@ -75,7 +80,7 @@ public class UnaryServerCallHandler extends BaseCallHandler
 
           if (statusHeader.isPresent()
               && !statusHeader.firstValue().equals(Status.Code.OK.name())) {
-            final HttpHeader statusReasonHeader = resp.getHeaders().getHeader(GRPC_STATUS_REASON);
+            final HttpHeader statusReasonHeader = respHeaders.getHeader(GRPC_STATUS_REASON);
             final String reason =
                 statusReasonHeader.isPresent() ? statusReasonHeader.firstValue() : "";
 

--- a/src/test/java/org/wiremock/grpc/ResponseHeadersAcceptanceTest.java
+++ b/src/test/java/org/wiremock/grpc/ResponseHeadersAcceptanceTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2023-2025 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wiremock.grpc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.example.grpc.GreetingServiceGrpc;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.google.common.collect.Lists;
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.wiremock.grpc.client.GreetingsClient;
+import org.wiremock.grpc.dsl.WireMockGrpcService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ResponseHeadersAcceptanceTest {
+
+  public static final String X_MY_HEADER = "x-my-Header";
+  WireMockGrpcService mockGreetingService;
+  ManagedChannel managedChannel;
+  Channel channel;
+  GreetingsClient greetingsClient;
+  WireMock wireMock;
+
+  @RegisterExtension
+  public static WireMockExtension wm =
+      WireMockExtension.newInstance()
+          .options(
+              wireMockConfig()
+                  //                  .dynamicPort()
+                  .port(8282)
+                  .withRootDirectory("src/test/resources/wiremock")
+                  .extensions(new GrpcExtensionFactory()))
+          .build();
+
+  @BeforeEach
+  void init() {
+    wireMock = wm.getRuntimeInfo().getWireMock();
+    mockGreetingService = new WireMockGrpcService(wireMock, GreetingServiceGrpc.SERVICE_NAME);
+
+    managedChannel =
+        ManagedChannelBuilder.forAddress("localhost", wm.getPort()).usePlaintext().build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    managedChannel.shutdown();
+  }
+
+  @Test
+  void httpResponseHeadersAreAddedToTheGrpcTrailers() {
+    AtomicReference<Metadata> headersCapture = new AtomicReference<>();
+    AtomicReference<Metadata> trailersCapture = new AtomicReference<>();
+    ClientInterceptor metadataInterceptor = MetadataUtils.newCaptureMetadataInterceptor(headersCapture, trailersCapture);
+    channel = ClientInterceptors.intercept(managedChannel, metadataInterceptor);
+
+    greetingsClient = new GreetingsClient(channel);
+    wm.stubFor(
+        post(urlPathEqualTo("/com.example.grpc.GreetingService/greeting"))
+            .willReturn(
+                okJson("{\n" + "    \"greeting\": \"Howdy!\"\n" + "}")
+                    .withHeader(X_MY_HEADER, "first", "second", "third")));
+
+    String greeting = greetingsClient.greet("Whatever");
+
+    assertThat(greeting, is("Howdy!"));
+
+    Metadata.Key<String> key = Metadata.Key.of("x-my-header", Metadata.ASCII_STRING_MARSHALLER);
+    ArrayList<String> values = Lists.newArrayList(headersCapture.get().getAll(key));
+    assertThat(values, is(List.of("first", "second", "third")));
+  }
+}


### PR DESCRIPTION
Yesterday I raised [a pull request](https://github.com/wiremock/wiremock-grpc-extension/pull/187) to copy the http response headers into the grpc trailers. After thinking about it some more whilst trying and failing to get to sleep last night, I decided they should probably be copied into the grpc headers instead. So now I'm raising this PR, too. I'll leave someone who knows more about this than me to decide which is right.

(This is to fix [issue 128](https://github.com/wiremock/wiremock-grpc-extension/issues/128).)

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
